### PR TITLE
Add onbase_document frontend components...

### DIFF
--- a/backend/controllers/onbase_document.rb
+++ b/backend/controllers/onbase_document.rb
@@ -1,7 +1,7 @@
 class ArchivesSpaceService < Sinatra::Base
 
 
-  Endpoint.post('/onbase_documentss/:id')
+  Endpoint.post('/onbase_documents/:id')
     .description("Update an Onbase Document")
     .params(["id", :id],
             ["onbase_document", JSONModel(:onbase_document), "The updated record", :body => true])
@@ -52,4 +52,14 @@ class ArchivesSpaceService < Sinatra::Base
     handle_delete(OnbaseDocument, params[:id])
   end
 
+
+  Endpoint.get('/search/onbase_document')
+  .description("Search across OnBase Documents")
+  .params(*BASE_SEARCH_PARAMS)
+  .permissions([])
+  .paginated(true)
+  .returns([200, ""]) \
+  do
+    json_response(Search.search(params.merge(:type => ['onbase_document']), nil))
+  end
 end

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,5 @@
+repository_menu_controller: onbase_documents
+parents:
+  accession:
+    name: onbase_documents
+    cardinality: zero_to_many

--- a/frontend/assets/onbase_document.crud.js
+++ b/frontend/assets/onbase_document.crud.js
@@ -1,0 +1,13 @@
+function OnBaseRecordForm($container) {
+  this.$container = $container;
+
+  this.setup();
+};
+
+OnBaseRecordForm.prototype.setup = function() {
+  this.$container.on("click", "#importOnBaseRecord", function(event) {
+    event.preventDefault();
+
+    alert("TODO: Make this AJAX POST the document and use resulting JSON to populate the form below")
+  });
+};

--- a/frontend/controllers/onbase_documents_controller.rb
+++ b/frontend/controllers/onbase_documents_controller.rb
@@ -1,0 +1,65 @@
+class OnbaseDocumentsController < ApplicationController
+
+  set_access_control  "view_repository" => [:index, :show],
+                      "manage_repository" => [:new, :edit, :create, :update, :merge, :delete]
+
+
+
+  def index
+    @search_data = Search.global({"sort" => "title_sort asc"}.merge(params_for_backend_search.merge({"facet[]" => SearchResultData.BASE_FACETS})),
+                                 "onbase_document")
+  end
+
+  def show
+    @onbase_document = JSONModel(:onbase_document).find(params[:id])
+  end
+
+  def new
+    @onbase_document = JSONModel(:onbase_document).new._always_valid!
+
+    render_aspace_partial :partial => "onbase_documents/new" if inline?
+  end
+
+  def edit
+    @onbase_document = JSONModel(:onbase_document).find(params[:id])
+  end
+
+  def create
+    handle_crud(:instance => :onbase_document,
+                :model => JSONModel(:onbase_document),
+                :on_invalid => ->(){
+                  return render_aspace_partial :partial => "onbase_documents/new" if inline?
+                  return render :action => :new
+                },
+                :on_valid => ->(id){
+                  if inline?
+                    render :json => @onbase_document.to_hash if inline?
+                  else
+                    flash[:success] = I18n.t("plugins.onbase_document._frontend.messages.created")
+                    return redirect_to :controller => :onbase_documents, :action => :new if params.has_key?(:plus_one)
+                    redirect_to :controller => :onbase_documents, :action => :edit, :id => id
+                  end
+                })
+  end
+
+  def update
+    handle_crud(:instance => :onbase_document,
+                :model => JSONModel(:onbase_document),
+                :obj => JSONModel(:onbase_document).find(params[:id]),
+                :on_invalid => ->(){ return render :action => :edit },
+                :on_valid => ->(id){
+                  flash[:success] = I18n.t("plugins.onbase_document._frontend.messages.updated")
+                  redirect_to :controller => :onbase_documents, :action => :edit, :id => id
+                })
+  end
+
+  def delete
+    onbase_document = JSONModel(:onbase_document).find(params[:id])
+    onbase_document.delete
+
+    flash[:success] = I18n.t("plugins.onbase_document._frontend.messages.deleted", JSONModelI18nWrapper.new(:onbase_document => onbase_document))
+    redirect_to(:controller => :onbase_documents, :action => :index, :deleted_uri => onbase_document.uri)
+  end
+
+
+end

--- a/frontend/locales/en.yml
+++ b/frontend/locales/en.yml
@@ -1,0 +1,22 @@
+en:
+  plugins:
+    aspace_onbase:
+      _plural: OnBase Documents
+      _singular: OnBase Document
+    onbase_documents:
+      label: OnBase Documents
+    onbase_document: &onbase_document_attributes
+      _plural: OnBase Documents
+      _singular: OnBase Document
+      onbase_id: OnBase ID
+      name: Name
+      keywords: Keywords
+      _frontend:
+        action:
+          add: Add OnBase Document
+          save: Save OnBase Document
+          create: Create an OnBase Document
+        messages:
+          updated: OnBase Document Saved
+  onbase_document:
+    <<: *onbase_document_attributes

--- a/frontend/plugin_init.rb
+++ b/frontend/plugin_init.rb
@@ -1,0 +1,2 @@
+my_routes = [File.join(File.dirname(__FILE__), "routes.rb")]
+ArchivesSpace::Application.config.paths['config/routes'].concat(my_routes)

--- a/frontend/routes.rb
+++ b/frontend/routes.rb
@@ -1,0 +1,4 @@
+ArchivesSpace::Application.routes.draw do
+  match('/plugins/onbase_documents/:id' => 'onbase_documents#update', :via => [:post])
+  match('/plugins/onbase_documents/:id/delete' => 'onbase_documents#delete', :via => [:post])
+end

--- a/frontend/views/layout_head.html.erb
+++ b/frontend/views/layout_head.html.erb
@@ -1,0 +1,1 @@
+<%= javascript_include_tag "#{AppConfig[:frontend_prefix]}assets/onbase_document.crud.js" %>

--- a/frontend/views/onbase_documents/_form.html.erb
+++ b/frontend/views/onbase_documents/_form.html.erb
@@ -1,0 +1,46 @@
+<%= render_aspace_partial :partial => "shared/form_messages", :locals => {:object => @onbase_document, :form => form} %>
+
+<%
+  onBaseImportRequired = form.obj["onbase_id"].blank?
+%>
+
+<fieldset id="onbaseDocumentFormFields">
+  <% define_template "onbase_document", jsonmodel_definition(:onbase_document) do |form| %>
+    <section id="onBaseRecordDetails">
+      <h3>OnBase Record Details</h3>
+      <% if onBaseImportRequired %>
+        <div class="alert alert-warning">
+          OnBase Record fields will be populated and become editable once the document is imported to OnBase
+        </div>
+      <% end %>
+      <%= form.hidden_input "onbase_id", nil, {:disabled => onBaseImportRequired} %>
+      <%= form.label_and_readonly "onbase_id", "Document Import Required" %>
+      <%= form.label_and_textfield "name", {:field_opts => {:disabled => onBaseImportRequired}} %>
+      <%= form.label_and_textarea "keywords", {:field_opts => {:disabled => onBaseImportRequired}} %>
+    </section>
+  <% end %>
+
+  <% if onBaseImportRequired %>
+    <section id="importOnBaseRecordSection">
+      <h3>Import OnBase Record</h3>
+      <div class="form-group required">
+        <label class="col-sm-2 control-label" for="onbase_document_file_">File to Import</label>
+        <div class="col-sm-9">
+          <input class="form-control" id="onbase_document_file_" name="onbase_document[file]" type="file" value="">
+        </div>
+      </div>
+      <div class="form-group">
+        <div class="col-sm-2"></div>
+        <div class="col-sm-9">
+          <button class="btn btn-primary" id="importOnBaseRecord">Import File</button>
+        </div>
+      </div>
+    </section>
+  <% end %>
+
+  <% form.emit_template("onbase_document") %>
+</fieldset>
+
+<script>
+  new OnBaseRecordForm($("#onbaseDocumentFormFields"));
+</script>

--- a/frontend/views/onbase_documents/_linker.html.erb
+++ b/frontend/views/onbase_documents/_linker.html.erb
@@ -1,0 +1,42 @@
+<%
+   if form.obj['ref'].blank?
+     selected_json = "{}"
+   else
+     multiplicity = "one"
+     selected_json = form.obj['_resolved'].to_json
+   end
+
+   data_path = form.path
+   data_name = "ref" # De-referenced by the controller if the schema def calls for an item array
+
+   exclude_ids = [] if exclude_ids.blank?
+%>
+
+<div class="form-group required">
+  <label class="control-label col-sm-2"><%= I18n.t("plugins.onbase_document._singular") %></label>
+  <div class="controls col-sm-8">
+    <div class="input-group linker-wrapper">
+      <input type="text" class="linker"
+             id="<%= form.id_for(data_name) %>"
+             data-label="<%= I18n.t("onbase_document._singular") %>"
+             data-label_plural="<%= I18n.t("onbase_document._plural") %>"
+             data-path="<%= data_path %>"
+             data-name="<%= data_name %>"
+             data-url="<%= url_for :controller => :search, :action => :do_search, :format => :json %>"
+             data-browse-url="<%= url_for :controller => :search, :action => :do_search, :format => :js, :facets => SearchResultData.BASE_FACETS, :sort => "title_sort asc", :exclude => exclude_ids %>"
+             data-selected="<%= selected_json %>"
+             data-format_template="title"
+             data-multiplicity="one"
+             data-types='["onbase_document"]'
+             data-exclude='<%= exclude_ids.to_json %>'
+      />
+      <div class="input-group-btn">
+        <a class="btn btn-default dropdown-toggle last" data-toggle="dropdown" href="javascript:void(0);"><span class="caret"></span></a>
+        <ul class="dropdown-menu">
+          <li><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
+          <li><a href="javascript:void(0);" data-target="<%= url_for :controller => :onbase_documents, :action => :new, :inline => true %>" class="linker-create-btn"><%= I18n.t("actions.create") %></a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/views/onbase_documents/_new.html.erb
+++ b/frontend/views/onbase_documents/_new.html.erb
@@ -1,0 +1,6 @@
+<%= form_for @onbase_document, :as => "onbase_document", :url => {:action => :create}, :html => {:class => 'form-horizontal aspace-record-form'} do |f| %>
+  <%= form_context :onbase_document, @onbase_document do |form| %>
+    <%= hidden_field "inline", "true" %>
+    <%= render_aspace_partial :partial => "onbase_documents/form", :locals => {:form => form} %>
+  <% end %>
+<% end %>

--- a/frontend/views/onbase_documents/_sidebar.html.erb
+++ b/frontend/views/onbase_documents/_sidebar.html.erb
@@ -1,0 +1,8 @@
+<%= render(:layout => '/shared/sidebar',
+           :locals => {
+             :record_type => 'onbase_document',
+             :record => @onbase_document,
+             :plusone => false,
+             :suppress_basic_information => true
+           }) do |sidebar| %>
+<% end %>

--- a/frontend/views/onbase_documents/_template.html.erb
+++ b/frontend/views/onbase_documents/_template.html.erb
@@ -1,0 +1,5 @@
+<% define_template("onbase_document", jsonmodel_definition(:onbase_document)) do |form| %>
+  <div class="subrecord-form-fields">
+    <%= render_aspace_partial :partial => "onbase_documents/linker", :locals => { :form => form }%>
+  </div>
+<% end %>

--- a/frontend/views/onbase_documents/_toolbar.html.erb
+++ b/frontend/views/onbase_documents/_toolbar.html.erb
@@ -1,0 +1,27 @@
+<% if user_can?('manage_repository') %>
+  <div class="record-toolbar">
+    <% if ['new', 'create', 'edit', 'update'].include?(controller.action_name) %>
+      <div class="pull-left save-changes">
+        <button type="submit" class="btn btn-primary btn-sm"><%= I18n.t("actions.save_prefix") %></button>
+      </div>
+    <% else %>
+      <div class="btn-group pull-left">
+        <%= link_to I18n.t("actions.edit"), {:controller => :onbase_documents, :action => :edit, :id => @onbase_document.id}, :class => "btn btn-sm btn-primary" %>
+      </div>
+    <% end %>
+
+    <% if ['edit', 'update'].include?(controller.action_name) %>
+      <div class="pull-left revert-changes">
+        <%= link_to I18n.t("actions.revert"), {:controller => :onbase_documents, :action => :edit, :id => @onbase_document.id}, :class => "btn btn-sm btn-default" %>
+        <%= I18n.t("actions.toolbar_disabled_message") %>
+      </div>
+    <% end %>
+
+    <div class="btn-group btn-toolbar pull-right">
+      <div class="btn btn-inline-form">
+        <%= button_delete_action url_for(:controller => :onbase_documents, :action => :delete, :id => @onbase_document.id) %>
+      </div>
+    </div>
+    <div class="clearfix"></div>
+  </div>
+<% end %>

--- a/frontend/views/onbase_documents/edit.html.erb
+++ b/frontend/views/onbase_documents/edit.html.erb
@@ -1,0 +1,24 @@
+<%= setup_context :object => @onbase_document, :title => @onbase_document.name %>
+
+<%= form_for @onbase_document, :as => "onbase_document", :url => {:action => :update}, :html => {:class => 'form-horizontal aspace-record-form'}.merge(update_monitor_params(@onbase_document)) do |f| %>
+  <%= form_context :onbase_document, @onbase_document do |form| %>
+    <div class="row">
+      <div class="col-md-3">
+        <%= render_aspace_partial :partial => "sidebar" %>
+      </div>
+      <div class="col-md-9">
+        <%= render_aspace_partial :partial => "toolbar" %>
+        <div class="record-pane">
+          <%= link_to_help :topic => "onbase_document" %>
+          <h2><%= @onbase_document.name %>  <span class="label label-info"><%= I18n.t("onbase_document._singular") %></span></h2>
+          <br/>
+          <%= render_aspace_partial :partial => "onbase_documents/form", :locals => {:form => form} %>
+          <div class="form-actions">
+            <button type="submit" class="btn btn-primary"><%= I18n.t("onbase_document._frontend.action.save") %></button>
+            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+          </div>
+        </div>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/frontend/views/onbase_documents/index.html.erb
+++ b/frontend/views/onbase_documents/index.html.erb
@@ -1,0 +1,33 @@
+<%= setup_context(:title => I18n.t("plugins.onbase_document._plural")) %>
+
+<%
+   @show_multiselect_column = false
+%>
+
+<div class="row">
+  <div class="col-md-3">
+    <div class="sidebar">
+      <%= render_aspace_partial :partial => "search/filter" %>
+    </div>
+  </div>
+  <div class="col-md-9">
+    <% if user_can?('manage_repository') %>
+      <div class="record-toolbar">
+        <div class="btn-group pull-right">
+          <%= link_to I18n.t("plugins.onbase_document._frontend.action.create"), {:controller => :onbase_documents, :action => :new}, :class => "btn btn-sm btn-default" %>
+        </div>
+        <br style="clear:both" />
+      </div>
+    <% end %>
+
+    <div class="record-pane">
+      <%= link_to_help :topic => "search" %>
+
+      <h2><%= I18n.t("plugins.onbase_document._plural") %></h2>
+
+      <%= render_aspace_partial :partial => "shared/flash_messages" %>
+
+      <%= render_aspace_partial :partial => "search/listing" %>
+    </div>
+  </div>
+</div>

--- a/frontend/views/onbase_documents/new.html.erb
+++ b/frontend/views/onbase_documents/new.html.erb
@@ -1,0 +1,26 @@
+<%= setup_context :object => @onbase_document %>
+
+<%= form_for @onbase_document, :as => "onbase_document", :url => {:action => :create}, :html => {:class => 'form-horizontal aspace-record-form'} do |f| %>
+  <%= form_context :onbase_document, @onbase_document do |form| %>
+    <div class="row">
+      <div class="col-md-3">
+        <%= render_aspace_partial :partial => "sidebar" %>
+      </div>
+      <div class="col-md-9">
+        <%= render_aspace_partial :partial => "shared/toolbar_new_records" %>
+        <div class="record-pane">
+          <%= link_to_help :topic => "onbase_document" %>
+          <h2><%= I18n.t("actions.new_prefix") %> <%= I18n.t("plugins.onbase_document._singular") %>  <span class="label label-info"><%= I18n.t("plugins.onbase_document._singular") %></span></h2>
+          <br/>
+          <%= render_aspace_partial :partial => "onbase_documents/form", :locals => {:form => form} %>
+          <div class="form-actions">
+            <div class="btn-group">
+              <button type="submit" class="btn btn-primary"><%= I18n.t("plugins.onbase_document._frontend.action.save") %></button>
+            </div>
+            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel btn-default" %>
+          </div>
+        </div>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/frontend/views/onbase_documents/show.html.erb
+++ b/frontend/views/onbase_documents/show.html.erb
@@ -1,0 +1,30 @@
+<%= setup_context :object => @onbase_document, :title => @onbase_document.name %>
+
+<div class="row">
+   <div class="col-md-3">
+      <%= render_aspace_partial :partial => "sidebar" %>
+   </div>
+   <div class="col-md-9">
+    <%= render_aspace_partial :partial => "toolbar" %>
+    <div class="record-pane">
+     <%= readonly_context :onbase_document, @onbase_document do |readonly| %>
+      <h2><%= @onbase_document.name %>  <span class="label label-info"><%= I18n.t("onbase_document._singular") %></span></h2>
+
+      <%= render_aspace_partial :partial => "shared/flash_messages" %>
+
+      <% define_template "onbase_document", jsonmodel_definition(:onbase_document) do |form, onbase_document| %>
+        <section id="basic_information">
+
+          <%= form.label_and_textfield "onbase_id" %>
+          <%= form.label_and_textfield "name" %>
+          <%= form.label_and_textfield "keywords" %>
+
+          <%= display_audit_info(@onbase_document) %>
+        </section>
+      <% end %>
+
+      <%= readonly.emit_template "onbase_document" %>
+    <% end %>
+   </div>
+  </div>
+</div>

--- a/indexer/aspace_onbase_indexer.rb
+++ b/indexer/aspace_onbase_indexer.rb
@@ -1,0 +1,16 @@
+class CommonIndexer
+
+  @@record_types << :onbase_document
+
+  add_indexer_initialize_hook do |indexer|
+
+    indexer.add_document_prepare_hook {|doc, record|
+      if record['record']['jsonmodel_type'] == 'onbase_document'
+        doc['title'] = "#{record['record']['name']} [#{record['record']['onbase_id']}]"
+        doc['display_string'] = doc['title']
+      end
+    }
+
+  end
+
+end

--- a/schemas/accession_ext.rb
+++ b/schemas/accession_ext.rb
@@ -1,0 +1,19 @@
+{
+  "onbase_documents" => {
+    "type" => "array",
+    "items" => {
+      "type" => "object",
+      "subtype" => "ref",
+      "properties" => {
+        "ref" => {
+          "type" => "JSONModel(:onbase_document) uri",
+          "ifmissing" => "error"
+        },
+        "_resolved" => {
+          "type" => "object",
+          "readonly" => "true"
+        }
+      }
+    }
+  },
+}


### PR DESCRIPTION
Namely:
- frontend onbase_document controller
- introduce schema extension for linking into an Accession
- frontend onbase_document templates for CRUD, including inline templates for creation via a linker
- basic indexing of an onbase_document
- global search for onbase_documents and frontend index page
- stub new form with file import, button and custom javascript hook

So basically, the framework is now there for the standard CRUD workflows.  

Next: introduce the frontend controller endpoints to support taking a file and sending it to the backend and modify the custom javascript hook to do this in a nice AJAX-y manner.
