### PR TITLE
[Delivers #105853304] expose more about the onbase_record's state

### DIFF
--- a/backend/model/onbase_document.rb
+++ b/backend/model/onbase_document.rb
@@ -7,14 +7,27 @@ class OnbaseDocument < Sequel::Model(:onbase_document)
   set_model_scope :repository
 
   def display_string
-    "#{filename} - #{document_type} [#{onbase_id}] :: #{linked_record_display}"
+    (deletion_pending? ? "[Deletion Pending] " : "") + "#{filename} - #{document_type} [#{onbase_id}] :: #{linked_record_display}"
   end
+
+
+  def deletion_pending?
+    linked_record_uri.nil? && was_linked == 1
+  end
+
+
+  def new_and_unlinked?
+    linked_record_uri.nil? && was_linked == 0
+  end
+
 
   def self.sequel_to_jsonmodel(objs, opts = {})
     jsons = super
 
     jsons.zip(objs).each do |json, obj|
       json['display_string'] = obj.display_string
+      json['deletion_pending'] = obj.deletion_pending?
+      json['new_and_unlinked'] = obj.new_and_unlinked?
       json['linked_record'] = {
         'ref' => obj.linked_record_uri
       }

--- a/frontend/controllers/onbase_documents_controller.rb
+++ b/frontend/controllers/onbase_documents_controller.rb
@@ -4,7 +4,7 @@ class OnbaseDocumentsController < ApplicationController
                       "manage_onbase_record" => [:new, :create, :keywords_form, :unlink]
 
 
-  SEARCH_FACETS = ["document_type_u_ustr", "mime_type_u_ustr", "linked_to_record_u_ubool"]
+  SEARCH_FACETS = ["document_type_u_ustr", "mime_type_u_ustr", "linked_to_record_u_ubool", "deletion_pending_u_ubool", "new_and_unlinked_u_ubool"]
 
 
   def index

--- a/frontend/locales/en.yml
+++ b/frontend/locales/en.yml
@@ -41,8 +41,9 @@ en:
           type_not_supported: "Type not supported: %{type}"
           no_keywords: There are no keywords stored in OnBase for this document
           delete: This action will queue the OnBase Document to be deleted from both ArchivesSpace and OnBase. This action cannot be undone.
-          unlinked: OnBase Document is unlinked
-
+          new_and_unlinked: OnBase Document has not been linked to a record (and cannot be deleted)
+          deletion_pending: This OnBase Document is no longer linked to a record and will be removed when the delete job is next run.
+          unlinked_document: New, unlinked Record. This OnBase Document has not yet been linked to a record. When adding a new OnBase Document, click 'link to an existing OnBase Document' to search for and select this record.
     onbase_document_keyword:
       linked_record_system_id: Record ID
       agent_system_id: Agent ID
@@ -61,5 +62,17 @@ en:
       document_type_u_ustr: Document Type
       mime_type_u_ustr: MIME-type
       linked_to_record_u_ubool: Linked to Record
+      deletion_pending_u_ubool: Deletion Pending
+      new_and_unlinked_u_ubool: New and Unlinked
+    filter_terms:
+      linked_to_record_u_ubool:
+        "true": "Yes"
+        "false": "No"
+      deletion_pending_u_ubool:
+        "true": "Yes"
+        "false": "No"
+      new_and_unlinked_u_ubool:
+        "true": "Yes"
+        "false": "No"
   onbase_document:
     <<: *onbase_document_attributes

--- a/frontend/plugin_init.rb
+++ b/frontend/plugin_init.rb
@@ -46,6 +46,18 @@ Rails.application.config.after_initialize do
   end
 
 
+  SearchResultData.class_eval do
+    alias_method :facet_label_string_pre_aspace_onbase, :facet_label_string
+    def facet_label_string(facet_group, facet)
+      if ["linked_to_record_u_ubool", "deletion_pending_u_ubool", "new_and_unlinked_u_ubool"].include?(facet_group)
+        return I18n.t("search_results.filter_terms.#{facet_group}.#{facet.to_s}", :default => facet.to_s)
+      end
+
+      facet_label_string_pre_aspace_onbase(facet_group, facet)
+    end
+  end
+
+
   # force load our JSONModels so the are registered rather than lazy initialised
   # we need this for parse_reference to work
   JSONModel(:onbase_document)

--- a/frontend/views/onbase_documents/_toolbar.html.erb
+++ b/frontend/views/onbase_documents/_toolbar.html.erb
@@ -5,15 +5,17 @@
         <button type="submit" class="btn btn-primary btn-sm"><%= I18n.t("actions.save_prefix") %></button>
       </div>
     <% end %>
-    <div class="btn btn-inline-form pull-right">
-        <%= button_delete_action url_for(:controller => :onbase_documents, :action => :unlink, :id => @onbase_document.id),
-          {
-            :label => I18n.t("plugins.onbase_document._frontend.action.delete"),
-            :"data-title" => I18n.t("plugins.onbase_document._frontend.action.delete"),
-            :"data-message" => I18n.t("plugins.onbase_document._frontend.messages.delete")
-          }
-        %>
-    </div>
+    <% if !@onbase_document['new_and_unlinked'] && !@onbase_document['deletion_pending'] %>
+      <div class="btn btn-inline-form pull-right">
+          <%= button_delete_action url_for(:controller => :onbase_documents, :action => :unlink, :id => @onbase_document.id),
+            {
+              :label => I18n.t("plugins.onbase_document._frontend.action.delete"),
+              :"data-title" => I18n.t("plugins.onbase_document._frontend.action.delete"),
+              :"data-message" => I18n.t("plugins.onbase_document._frontend.messages.delete")
+            }
+          %>
+      </div>
+    <% end %>
     <div class="clearfix"></div>
   </div>
 <% end %>

--- a/frontend/views/onbase_documents/show.html.erb
+++ b/frontend/views/onbase_documents/show.html.erb
@@ -14,9 +14,13 @@
       }
      %>
 
-      <% if @onbase_document['linked_record'].blank? || @onbase_document['linked_record']['ref'].blank? %>
+      <% if @onbase_document['deletion_pending'] %>
         <div class="alert alert-warning">
-          <%= I18n.t("plugins.onbase_document._frontend.messages.unlinked") %>
+          <%= I18n.t("plugins.onbase_document._frontend.messages.deletion_pending") %>
+        </div>
+      <% elsif @onbase_document['new_and_unlinked'] %>
+        <div class="alert alert-warning">
+          <%= I18n.t("plugins.onbase_document._frontend.messages.new_and_unlinked") %>
         </div>
       <% end %>
 

--- a/indexer/aspace_onbase_indexer.rb
+++ b/indexer/aspace_onbase_indexer.rb
@@ -10,6 +10,8 @@ class CommonIndexer
         doc['document_type_u_ustr'] = record['record']['document_type']
         doc['mime_type_u_ustr'] = record['record']['mime_type']
         doc['linked_to_record_u_ubool'] = !!record['record']['linked_record']
+        doc['deletion_pending_u_ubool'] = !!record['record']['deletion_pending']
+        doc['new_and_unlinked_u_ubool'] = !!record['record']['new_and_unlinked']
       end
     }
 

--- a/migrations/006_reindex_onbase_documents.rb
+++ b/migrations/006_reindex_onbase_documents.rb
@@ -1,0 +1,9 @@
+require 'db/migrations/utils'
+
+Sequel.migration do
+
+  up do
+    self[:onbase_document].update(:system_mtime => Time.now)
+  end
+
+end

--- a/schemas/onbase_document.rb
+++ b/schemas/onbase_document.rb
@@ -37,6 +37,8 @@
           }
         }
       },
+      "deletion_pending" => {"type" => "boolean", "readonly" => "true", "default" => false},
+      "new_and_unlinked" => {"type" => "boolean", "readonly" => "true", "default" => true}
     },
   },
 }


### PR DESCRIPTION
Add deletion_pending and new_and_unlinked readonly attributes to the onbase_document record JSON.  Expose these new fields as facets on the search page (I18n this facet groups and facet terms nicely too).

If deletion_pending, show this in the display_string, a message on the readonly view and remove the "Delete" button from the toolbar.

If new_and_unlinked show a message on the readonly view and remove the "Delete" button from the toolbar.

Add a migration to reindex all onbase_documents to pick up the new display_string bits.
