### PR TITLE
Updates to fix keyword generation and chnages to AS as db of Record

### DIFF
--- a/backend/model/onbase_client.rb
+++ b/backend/model/onbase_client.rb
@@ -80,7 +80,6 @@ class OnbaseClient
       req['Content-type'] = 'text/json'
       req.body = json
       req.basic_auth @username, @password
-      Log.debug("body: #{json.inspect}")
       response = http.request(req)
 
       if response.code !~ /^2/

--- a/backend/model/onbase_keyword_job.rb
+++ b/backend/model/onbase_keyword_job.rb
@@ -4,7 +4,7 @@ class OnbaseKeywordJob < Sequel::Model(:onbase_keyword_job)
 
   def self.create(onbase_document, keywords, user)
     super(:onbase_id => onbase_document.onbase_id,
-          :keywords => keywords.to_json,
+          :keywords => keywords.to_a.to_json, #convert hash to array first to preserve the duplicate keys that may be found in the hash
           :status => "new",
           :user => user,
           :system_mtime => Time.now)

--- a/lib/document_keyword_definitions.rb
+++ b/lib/document_keyword_definitions.rb
@@ -2,15 +2,17 @@ class DocumentKeywordDefinitions
 
   DOCUMENT_TYPE_DEFINITIONS = {
     "SPCL - Agent Correspondence" => {
-      :supported_records => [:event],
+      :supported_records => [:archival_object, :event],
       :fields => [
         {:type => "generated", :generator => :agent_name},
         {:type => "generated", :generator => :event_system_id},
         {:type => "generated", :generator => :agent_system_id},
+        {:type => "generated", :generator => :linked_record_system_id},
+        {:type => "generated", :generator => :record_identifier}#
       ]},
 
     "SPCL - Deed" => {
-      :supported_records => [:event],
+      :supported_records => [:archival_object, :event],
       :fields => [
         {:type => "generated", :generator => :agent_name},
         {:type => "generated", :generator => :event_system_id},
@@ -30,7 +32,7 @@ class DocumentKeywordDefinitions
       ]},
 
     "SPCL - Dealer Object Description" => {
-      :supported_records => [:event],
+      :supported_records => [:archival_object, :event],
       :fields => [
         {:type => "generated", :generator => :agent_name},
         {:type => "generated", :generator => :event_system_id},
@@ -40,7 +42,7 @@ class DocumentKeywordDefinitions
       ]},
     
     "SPCL - Dealer Invoice" => {
-      :supported_records => [:event],
+      :supported_records => [:archival_object, :event],
       :fields => [
         {:type => "generated", :generator => :agent_name},
         {:type => "generated", :generator => :event_system_id},
@@ -96,7 +98,7 @@ class DocumentKeywordDefinitions
       ]},
 
     "SPCL - Oral History Release Form" => {
-      :supported_records => [:event],
+      :supported_records => [:archival_object, :event],
       :fields => [
         {:type => "generated", :generator => :agent_name},
         {:type => "generated", :generator => :event_system_id},
@@ -105,7 +107,7 @@ class DocumentKeywordDefinitions
       ]},
 
     "SPCL - Deaccession Record" => {
-      :supported_records => [:event],
+      :supported_records => [:archival_object, :event],
       :fields => [
         {:type => "generated", :generator => :event_system_id},
         {:type => "generated", :generator => :linked_record_system_id},
@@ -121,10 +123,12 @@ class DocumentKeywordDefinitions
       ]},
 
     "SPCL - Permission to Publish Form" => {
-      :supported_records => [:event],
+      :supported_records => [:archival_object, :event],
       :fields => [
         {:type => "generated", :generator => :agent_name},
         {:type => "generated", :generator => :event_system_id},
+        {:type => "generated", :generator => :linked_record_system_id},
+        {:type => "generated", :generator => :record_identifier},
       ]},
 
     "SPCL - Loan Agreement" => {


### PR DESCRIPTION
This changes the way that keywords are updated as changes to records in ArchivesSpace are now sent to Onbase rather than preferencing already set keywords retrieved from OnBase.

Also changes the way that linked agents names and ids are generated. Agent names are now sent as individual keywords rather than as a concatenated string.

All linked agent ids, records id, etc are now sent rather than just the last in the queue.

Adds ability to generate/use a keyword hash that contains duplicate keyword names.
